### PR TITLE
Only send advancements to Velocity that are broadcast to the in-game chat

### DIFF
--- a/src/main/java/ooo/foooooooooooo/yep/mixin/PlayerAdvancementTrackerMixin.java
+++ b/src/main/java/ooo/foooooooooooo/yep/mixin/PlayerAdvancementTrackerMixin.java
@@ -1,7 +1,6 @@
 package ooo.foooooooooooo.yep.mixin;
 
 import net.minecraft.advancement.Advancement;
-import net.minecraft.advancement.AdvancementProgress;
 import net.minecraft.advancement.PlayerAdvancementTracker;
 import net.minecraft.server.network.ServerPlayerEntity;
 import ooo.foooooooooooo.yep.events.AdvancementCallback;
@@ -14,18 +13,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(PlayerAdvancementTracker.class)
 public class PlayerAdvancementTrackerMixin {
     @Shadow
-    public AdvancementProgress getProgress(Advancement advancement) {
-        return null;
-    }
-
-    @Shadow
     private ServerPlayerEntity owner;
 
-    @Inject(method = "grantCriterion", at = @At(value = "TAIL"))
+    @Inject(method = "grantCriterion", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/PlayerManager;broadcast(Lnet/minecraft/text/Text;Z)V"))
     public void onAdvancement(Advancement advancement, String criterionName, CallbackInfoReturnable<Boolean> cir) {
-        AdvancementProgress advancementProgress = this.getProgress(advancement);
-        if (advancementProgress.isDone()) {
-            AdvancementCallback.EVENT.invoker().getAdvancement(this.owner, advancement);
-        }
+        AdvancementCallback.EVENT.invoker().getAdvancement(this.owner, advancement);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,8 +9,8 @@
         "fooooooooooooooo"
     ],
     "contact": {
-        "homepage": "https://github.com/fooooooooooooooo/Yep",
-        "sources": "https://github.com/fooooooooooooooo/Yep"
+        "homepage": "https://github.com/fooooooooooooooo/yep-paper/tree/fabric",
+        "sources": "https://github.com/fooooooooooooooo/yep-paper/tree/fabric"
     },
 
     "license": "MIT",


### PR DESCRIPTION
this prevents, for example, the "initial" advancements from being sent to Velocity, such as "Minecraft" ("The heart and story of the game") and "Adventure" ("Adventure, exploration and combat").

it also stops advancements from being sent to Velocity when the "announceAdvancements" gamerule is set to "false". this makes sense to me, but what do you think?

(also, it seems that VelocityDiscord can't handle any advancements with colons in the title or description; it prints an "index out of bounds" error.
some solutions i thought of were to either use some other (non-conforming?) character to split the parts of the plugin message, or to send each part of the message separately; that being the player's username, the advancement's title, and the advancement's description.
a datapack with such an advancement can be found here: https://modrinth.com/datapack/tc-woodcutter/version/1.0.0 )