### PR TITLE
[Forge 1.7.10] Only send achievements that are actually sent to chat

### DIFF
--- a/src/main/java/ooo/foooooooooooo/yep/EventListener.java
+++ b/src/main/java/ooo/foooooooooooo/yep/EventListener.java
@@ -7,7 +7,7 @@ import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.IChatComponent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.player.AchievementEvent;
-import ooo.foooooooooooo.yep.messages.AchievementMessage;
+import ooo.foooooooooooo.yep.messages.AdvancementMessage;
 import ooo.foooooooooooo.yep.messages.DeathMessage;
 
 public class EventListener {
@@ -33,7 +33,7 @@ public class EventListener {
         var title = getComponentText(new ChatComponentTranslation(achievement.statId));
         var description = getComponentText(new ChatComponentTranslation(achievement.statId + ".desc"));
 
-        PluginMessenger.sendMessage((EntityPlayerMP) event.entityPlayer, new AchievementMessage(title, description));
+                PluginMessenger.sendMessage((EntityPlayerMP) event.entityPlayer, new AdvancementMessage(title, description));
     }
 
     private static String getComponentText(IChatComponent component) {

--- a/src/main/java/ooo/foooooooooooo/yep/EventListener.java
+++ b/src/main/java/ooo/foooooooooooo/yep/EventListener.java
@@ -15,6 +15,7 @@ public class EventListener {
     public void onDeathEvent(LivingDeathEvent event) {
         if (event.entityLiving instanceof EntityPlayerMP player) {
             var username = player.getDisplayName();
+            // func_151519_b() = get death message from source
             var message = getComponentText(event.source.func_151519_b(player)).replace(username + " ", "");
 
             PluginMessenger.sendMessage(player, new DeathMessage(message));
@@ -24,16 +25,24 @@ public class EventListener {
     @SubscribeEvent
     public void onAchievementEvent(AchievementEvent event) {
         Achievement achievement = event.achievement;
+        EntityPlayerMP player = (EntityPlayerMP) event.entityPlayer;
 
-        if (event.achievement.isIndependent) {
-            Yep.LOGGER.trace("Ignoring local achievement");
-            return;
+        // if ("announce-player-achievements" == true)
+        if (player.mcServer.func_147136_ar()) {
+            // if (player can unlock achievement (i.e. prereqs are met) && player does NOT already have achievement)
+            if (player.func_147099_x().canUnlockAchievement(achievement) && !player.func_147099_x().hasAchievementUnlocked(achievement)) {
+                // if the achievement is only sent to chat on the client
+                if (achievement.isIndependent) {
+                    Yep.LOGGER.trace("Ignoring local achievement");
+                    return;
+                }
+
+                var title = getComponentText(new ChatComponentTranslation(achievement.statId));
+                var description = getComponentText(new ChatComponentTranslation(achievement.statId + ".desc"));
+
+                PluginMessenger.sendMessage(player, new AdvancementMessage(title, description));
+            }
         }
-
-        var title = getComponentText(new ChatComponentTranslation(achievement.statId));
-        var description = getComponentText(new ChatComponentTranslation(achievement.statId + ".desc"));
-
-                PluginMessenger.sendMessage((EntityPlayerMP) event.entityPlayer, new AdvancementMessage(title, description));
     }
 
     private static String getComponentText(IChatComponent component) {

--- a/src/main/java/ooo/foooooooooooo/yep/Yep.java
+++ b/src/main/java/ooo/foooooooooooo/yep/Yep.java
@@ -28,7 +28,7 @@ public class Yep {
 
     // make sure the client doesn't think it needs yep to connect
     @NetworkCheckHandler
-    public boolean checkModList(Map<String, String> modList, Side side) {
+    public boolean checkModLists(Map<String, String> modList, Side side) {
         return true;
     }
 }

--- a/src/main/java/ooo/foooooooooooo/yep/messages/AdvancementMessage.java
+++ b/src/main/java/ooo/foooooooooooo/yep/messages/AdvancementMessage.java
@@ -1,10 +1,10 @@
 package ooo.foooooooooooo.yep.messages;
 
-public class AchievementMessage implements IYepMessage {
+public class AdvancementMessage implements IYepMessage {
     private final String title;
     private final String description;
 
-    public AchievementMessage(String title, String description) {
+    public AdvancementMessage(String title, String description) {
         this.title = title;
         this.description = description;
     }


### PR DESCRIPTION
Currently, achievements get sent *every* time their criteria is met - i.e. "Getting Wood" would be displayed in Discord *every single time* the player picked up wood, which was not ideal.

This PR fixes that by verifying that the player both does not yet have the achievement unlocked, and is actually able to unlock the achievement (i.e. the previous required achievement(s) are unlocked).

(how Forge devs used to live with just SRG is beyond me)